### PR TITLE
Replace array operations with string operations.

### DIFF
--- a/oembed-gist-files.php
+++ b/oembed-gist-files.php
@@ -40,21 +40,25 @@ class OEmbed_Gist {
 	 * @return string
 	 */
 	public function gist_result( $url ) {
-		$url      = $url[0];
+		$url      = strtolower( $url[0] );
 		$fragment = '';
 		$parsed   = explode( '#', $url );
 
 		// Parse elements of URL for specific file within Gist.
 		if ( isset( $parsed[1] ) ) {
+			if ( str_contains( $url, '.js#' ) ) {
+				$url = str_replace( '.js#file-', '.js?file=', $url );
+			} else {
+				$url = str_replace( '#file-', '.js?file=', $url );
+			}
+
 			$url      = $parsed[0];
 			$fragment = str_replace( 'file-', '', $parsed[1] );
 			$file_arr = explode( '-', $fragment );
 			$ext      = array_pop( $file_arr );
 			$fragment = implode( '-', $file_arr ) . '.' . $ext;
 			$fragment = '?file=' . $fragment;
-		}
-
-		if ( ! str_ends_with( strtolower( $url ), '.js' ) ) {
+		} elseif ( ! str_ends_with( $url, '.js' ) ) {
 			$url .= '.js';
 		}
 

--- a/oembed-gist-files.php
+++ b/oembed-gist-files.php
@@ -40,29 +40,25 @@ class OEmbed_Gist {
 	 * @return string
 	 */
 	public function gist_result( $url ) {
-		$url      = strtolower( $url[0] );
-		$fragment = '';
-		$parsed   = explode( '#', $url );
+		$url = strtolower( $url[0] );
 
-		// Parse elements of URL for specific file within Gist.
-		if ( isset( $parsed[1] ) ) {
+		// Adjust the URL if it contains a specific file within the Gist.
+		$fragment = strpos( $url, '#' );
+		if ( false !== $fragment ) {
 			if ( str_contains( $url, '.js#' ) ) {
 				$url = str_replace( '.js#file-', '.js?file=', $url );
 			} else {
 				$url = str_replace( '#file-', '.js?file=', $url );
 			}
+			
+			$last_hyphen = strrpos( $url, '-' );
 
-			$url      = $parsed[0];
-			$fragment = str_replace( 'file-', '', $parsed[1] );
-			$file_arr = explode( '-', $fragment );
-			$ext      = array_pop( $file_arr );
-			$fragment = implode( '-', $file_arr ) . '.' . $ext;
-			$fragment = '?file=' . $fragment;
+			if ( false !== $last_hyphen && $last_hyphen > $fragment ) {
+				$url[ $last_hyphen ] = '.';
+			}
 		} elseif ( ! str_ends_with( $url, '.js' ) ) {
 			$url .= '.js';
 		}
-
-		$url = ! empty( $fragment ) ? $url . $fragment : $url;
 
 		// phpcs:ignore WordPress.WP.EnqueuedResources.NonEnqueuedScript
 		return '<script src="' . esc_url( $url ) . '"></script>';


### PR DESCRIPTION
Replacing array operations with string operations improves performance.

- Links with no file: Up to 27% faster.
- Links with files: Up to 50% faster.

https://3v4l.org/NJnKl