### PR TITLE
Add support for `wp_oembed_get()`.

### DIFF
--- a/oembed-gist-files.php
+++ b/oembed-gist-files.php
@@ -31,10 +31,17 @@ if ( ! defined( 'WPINC' ) ) {
 class OEmbed_Gist {
 
 	/**
+	 * The Gist regex to match.
+	 *
+	 * @var string
+	 */
+	private $regex = '#^https?://gist.github.com/.*#i';
+
+	/**
 	 * Constructor.
 	 */
 	public function __construct() {
-		wp_embed_register_handler( 'gist', '#^https?://gist.github.com/.*#i', [ $this, 'gist_result' ] );
+		wp_embed_register_handler( 'gist', $this->regex, [ $this, 'gist_result' ] );
 		add_filter( 'pre_oembed_result', [ $this, 'pre_oembed_result' ], 10, 2 );
 	}
 
@@ -79,7 +86,7 @@ class OEmbed_Gist {
 	 * @return string|null The Gist HTML, the existing HTML, or null.
 	 */
 	public function pre_oembed_result( $html, $url ) {
-		if ( preg_match( '#^https?://gist.github.com/.*#i', $url, $match ) ) {
+		if ( preg_match( $this->regex, $url, $match ) ) {
 			return $this->gist_result( $match );
 		}
 

--- a/oembed-gist-files.php
+++ b/oembed-gist-files.php
@@ -25,7 +25,9 @@ if ( ! defined( 'WPINC' ) ) {
 	die;
 }
 
-wp_embed_register_handler( 'gist', '#^https?://gist.github.com/.*#i', [ new OEmbed_Gist(), 'gist_result' ] );
+$oembed_gist = new OEmbed_Gist();
+wp_embed_register_handler( 'gist', '#^https?://gist.github.com/.*#i', [ $oembed_gist, 'gist_result' ] );
+add_filter( 'pre_oembed_result', [ $oembed_gist, 'pre_oembed_result' ], 10, 2 );
 
 /**
  * Class Gist_OEmbed.

--- a/oembed-gist-files.php
+++ b/oembed-gist-files.php
@@ -63,4 +63,20 @@ class OEmbed_Gist {
 		// phpcs:ignore WordPress.WP.EnqueuedResources.NonEnqueuedScript
 		return '<script src="' . esc_url( $url ) . '"></script>';
 	}
+
+	/**
+	 * Returns the HTML for a Gist.
+	 *
+	 * @param string|null $html The existing HTML, or null.
+	 * @param string      $url  The URL.
+	 *
+	 * @return string|null The Gist HTML, the existing HTML, or null.
+	 */
+	public function pre_oembed_result( $html, $url ) {
+		if ( preg_match( '#^https?://gist.github.com/.*#i', $url, $match ) ) {
+			return $this->gist_result( $match );
+		}
+
+		return $html;
+	}
 }

--- a/oembed-gist-files.php
+++ b/oembed-gist-files.php
@@ -25,14 +25,18 @@ if ( ! defined( 'WPINC' ) ) {
 	die;
 }
 
-$oembed_gist = new OEmbed_Gist();
-wp_embed_register_handler( 'gist', '#^https?://gist.github.com/.*#i', [ $oembed_gist, 'gist_result' ] );
-add_filter( 'pre_oembed_result', [ $oembed_gist, 'pre_oembed_result' ], 10, 2 );
-
 /**
  * Class Gist_OEmbed.
  */
 class OEmbed_Gist {
+
+	/**
+	 * Constructor.
+	 */
+	public function __construct() {
+		wp_embed_register_handler( 'gist', '#^https?://gist.github.com/.*#i', [ $this, 'gist_result' ] );
+		add_filter( 'pre_oembed_result', [ $this, 'pre_oembed_result' ], 10, 2 );
+	}
 
 	/**
 	 * Render Gist for embed.
@@ -82,3 +86,5 @@ class OEmbed_Gist {
 		return $html;
 	}
 }
+
+new OEmbed_Gist();


### PR DESCRIPTION
This PR adds support for `wp_oembed_get()` by filtering `pre_oembed_result`.

This PR also:
- Reduces the number of objects needed for `wp_embed_register_handler()` and `add_filter()` by moving them to the `::__construct()` method, and instantiating `OEmbed_Gist` at the end of the plugin file.
- Abstracts the regex pattern to a new `private` `$regex` property to avoid repetition.

### Testing Instructions
1. Checkout this PR.
2. Add the following to a plugin/theme:
```php
add_filter(
	'the_content',
	function( $content ) {
		$url = 'https://gist.github.com/costdev/e5bfde839a67d89d39af7c7df7fd28c9#file-file2-js';
		return $content . wp_oembed_get( $url );
	}
);
```
3. View any post.